### PR TITLE
Query exporter able to connect in a secure way to db through by bundle-cert

### DIFF
--- a/charts/query-exporter/templates/configmap-cert-db.yaml
+++ b/charts/query-exporter/templates/configmap-cert-db.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "query-exporter.fullname" . }}-cert-db
+  labels:
+    {{ include "query-exporter.labels" . | nindent 4 }}
+data:
+ query-exporter-cert-db.pem: |-
+  {{ tpl .Values.cert_db . | nindent 4 }}

--- a/charts/query-exporter/templates/deployment.yaml
+++ b/charts/query-exporter/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               readOnly: true
               name: {{ include "query-exporter.fullname" . }}
         {{- with .Values.extraVolumeMounts }}
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -98,7 +98,7 @@ spec:
               - key: config.yaml
                 path: config.yaml
     {{- with .Values.extraVolumes }}
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/query-exporter/values.yaml
+++ b/charts/query-exporter/values.yaml
@@ -132,3 +132,31 @@ exporter_config: |
       databases: [db1]
       metrics: [metric1]
       sql: SELECT random() / 1000000000000000 AS metric1
+
+# Implementation of SSL/TLS encrypted connection to the database.
+# The certificate for ssl is something generic, it is implemented in any 
+# database implementation, be it cloud or on-premise; however, we want to 
+# guide ourselves in something so that when we return to this in 6 months 
+# we know what we are talking about.
+
+# For that reason we attach documentation of aws rds aurora mysql to guide 
+# us in the configuration
+# https://docs.amazonaws.cn/en_us/AmazonRDS/latest/UserGuide/ssl-certificate-rotation-mysql.html
+
+# How to enforce for MYSQL SSL/TLS
+# Amazon RDS now support to enforce SSL/TLS connections, it is usefull in terms
+# of security side compliance.
+# flag: require_secure_transport
+# if your flag is require_secure_transport: true you need to enable the follwing section
+# extraVolumeMounts,extraVolumes and cert_db in order to upload a valid cert
+# inside the conectainer and it could be perform a ssl/tls secure connection.
+# Docs: https://aws.amazon.com/about-aws/whats-new/2022/08/amazon-rds-mysql-supports-ssl-tls-connections/ 
+
+# Where can I get a cert for RDS?
+# To get a certificate bundle that contains both the intermediate and root certificates for all AWS Regions, 
+# download from https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem.
+# Note: Also you can download your certificate bundle according to your region 
+# in the Certificate bundles for AWS Regions section.
+# ref: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html
+
+cert_db: ""


### PR DESCRIPTION
Dear @ingvarch 
Your project has been very useful to me to collect telemetry from a mysql to prometheus. Thank you for sharing your ideas.
We had the necessity to implement a secure connection via Tls/ssl
Query-Exporter is using https://www.sqlalchemy.org/ to handle connection, but this helm chart is not able to create volumes due an issue in ident. 

I show you a little about my implementation.
- I have corrected the ident of the volumes to avoid error in yaml
- I have created a new config map in order to mount the cert to k8s from a section called cert_db from the deployment template

#Evidence testing
- Pod describe
```
kubectl describe pod query-exporter-6bfdd965c8-pbm28 -n p1-metrics
Name:         query-exporter-xxxxxx-xxxxxx
Namespace:    p1-metrics
Priority:     0
Node:         ip-xxxxxxxxxx.us-west-2.compute.internal/10.117.193.195
Start Time:   Thu, 06 Oct 2022 17:33:05 -0600
Labels:       app.kubernetes.io/instance=query-exporter
              app.kubernetes.io/name=query-exporter
              pod-template-hash=6bfdd965c8
Annotations:  checksum/config: xxxxxxxxxxxxx
              kubernetes.io/psp: eks.privileged
Status:       Running
IP:           xxxxxxxx
IPs:
  IP:           xxxxxx
Controlled By:  ReplicaSet/query-exporter-xxxxxxx
Containers:
  query-exporter:
    Container ID:  containerd://xxxxxxxxxx
    Image:         adonato/query-exporter:2.7.0
    Image ID:      docker.io/adonato/query-exporter@sha256:xxxxxxxxxxxxx
    Port:          9560/TCP
    Host Port:     0/TCP
    Command:
      query-exporter
      -H
      0.0.0.0
      --
      /config/config.yaml
    State:          Running
      Started:      Thu, 06 Oct 2022 17:33:06 -0600
    Ready:          True
    Restart Count:  0
    Limits:
      memory:  512Mi
    Requests:
      cpu:      10m
      memory:   128Mi
    Liveness:   http-get http://:9560/ delay=60s timeout=2s period=30s #success=1 #failure=2
    Readiness:  http-get http://:9560/ delay=60s timeout=2s period=30s #success=1 #failure=4
    Environment Variables from:
      payfac-observability-secrets  Secret  Optional: false
    Environment:                    <none>
    Mounts:
      /config from query-exporter (ro)
      /etc/ssl/certs/query-exporter-cert-db.pem from query-exporter-cert-db (ro,path="query-exporter-cert-db.pem")
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-nvrvg (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  query-exporter:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      query-exporter
    Optional:  false
  query-exporter-cert-db:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      query-exporter-cert-db
    Optional:  false
  kube-api-access-nvrvg:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              failure-domain.beta.kubernetes.io/zone=us-west-2a
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age    From               Message
  ----    ------     ----   ----               -------
  Normal  Scheduled  3m11s  default-scheduler  Successfully assigned p1-metrics/query-exporter-6bfdd965c8-pbm28 to ip-10-117-193-195.us-west-2.compute.internal
  Normal  Pulled     3m10s  kubelet            Container image "adonato/query-exporter:2.7.0" already present on machine
  Normal  Created    3m10s  kubelet            Created container query-exporter
  Normal  Started    3m10s  kubelet            Started container query-exporter
```
volumen mounts
   Mounts:
```
      /config from query-exporter (ro)
      /etc/ssl/certs/query-exporter-cert-db.pem from query-exporter-cert-db (ro,path="query-exporter-cert-db.pem")
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-nvrvg (ro)
```

- shell inside the pod
```
root@query-exporter-6bfdd965c8-pbm28:/etc/ssl/certs# ls | grep "query" 
query-exporter-cert-db.pem
```

- Example of connection string
mysql+mysqldb://user:password@aurora-xxxxxxxxxxx.us-west-2.rds.amazonaws.com/p1ops?ssl_ca=/etc/ssl/certs/query-exporter-cert-db.pem

