### PR TITLE
fix: update query-exporter chart for 4.0.1 compatibility

### DIFF
--- a/charts/query-exporter/Chart.yaml
+++ b/charts/query-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "2.7.0"
+appVersion: "4.0.1"
 description: A Helm chart for Kubernetes to run query-exporter
 name: query-exporter
-version: 0.1.2
+version: 0.2.0
 home: https://github.com/albertodonato/query-exporter
 icon: https://helm.sh/img/helm-logo.svg
 keywords:

--- a/charts/query-exporter/values.yaml
+++ b/charts/query-exporter/values.yaml
@@ -3,9 +3,9 @@ replicaCount: 1
 
 image:
   repository: adonato/query-exporter
-  tag: 2.7.0
+  tag: 4.0.1
   pullPolicy: IfNotPresent
-  command: ["query-exporter", "-H", "0.0.0.0", "--", "/config/config.yaml"]
+  command: ["query-exporter", "-H", "0.0.0.0", "--config", "/config/config.yaml"]
 
 nameOverride: "query-exporter"
 fullnameOverride: "query-exporter"


### PR DESCRIPTION
Update chart to work with query-exporter 4.0.1. The CLI switched from argparse to Click, so the config file path must use --config instead of a positional argument. Also bumps image tag and chart version.